### PR TITLE
Standalone Sensor Mode - Allow overriding app_name and app_args for instrumented images

### DIFF
--- a/pkg/ipc/command/command.go
+++ b/pkg/ipc/command/command.go
@@ -41,6 +41,7 @@ type Message interface {
 // StartMonitor contains the start monitor command fields
 type StartMonitor struct {
 	RTASourcePT                  bool                          `json:"rta_source_ptrace"`
+	Entrypoint                   []string                      `json:"entrypoint,omitempty"`
 	AppName                      string                        `json:"app_name"`
 	AppArgs                      []string                      `json:"app_args,omitempty"`
 	AppUser                      string                        `json:"app_user,omitempty"`


### PR DESCRIPTION
The instrumented image must have the `commands.json` file baked in (based on the image's ENTRYPOINT and/or CMD). However, it's also possible to override the CMD by passing arguments to the `run` command. Since these args can't be known at runtime, sensor should be able to detect them and replace the `app_name` and `app_args` fields in the monitor start command it read from the baked in `commands.json` file.